### PR TITLE
Update to 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10.64'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.18.2
-	yarn_mappings=1.18.2+build.2
-	loader_version=0.13.3
+	minecraft_version=1.19
+	yarn_mappings=1.19+build.1
+	loader_version=0.14.7
 
 # Mod Properties
-	mod_version = 1.1.1
+	mod_version = 1.1.2
 	maven_group = com.vladmarica
 	archives_base_name = BetterPingDisplay-Fabric
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.48.0+1.18.2
+	fabric_version=0.55.3+1.19

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "betterpingdisplay",
-  "version": "1.1.1",
+  "version": "1.1.2",
 
   "name": "Better Ping Display",
   "description": "Shows the actual ping number instead of just bars in the player list!",
@@ -28,8 +28,8 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.12",
-    "minecraft": "1.18.x"
+    "fabricloader": ">=0.14",
+    "minecraft": "1.19.x"
   },
   "suggests": {}
 }


### PR DESCRIPTION
Update mappings, loader and Fabric API to 1.19. Update Loom to 0.12-SNAPSHOT (the version most 1.19 mods use). Changed mod version to 1.1.2. I tested it on some public servers and it works as expected. Please tell me if you create a 1.19.x branch so I can change this PR to target that.