### PR TITLE
Update to 1.19.4 and loosen fabric.mod.json version requirement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.1.+'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_14
-targetCompatibility = JavaVersion.VERSION_14
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -19,16 +19,10 @@ dependencies {
 }
 
 processResources {
-	inputs.property "version", project.version
-	duplicatesStrategy = 'warn'
+	inputs.property 'version', version
 
-	from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
-		expand "version": project.version
-	}
-
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
+	filesMatching('fabric.mod.json') {
+		expand 'version': version
 	}
 }
 
@@ -36,36 +30,19 @@ tasks.withType(JavaCompile) {
 	options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier = "sources"
-	from sourceSets.main.allSource
+java {
+	withSourcesJar()
 }
 
 jar {
 	from "LICENSE"
 }
 
-// configure the maven publication
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-			// add all the jars that should be included when publishing to maven
-			artifact(remapJar) {
-				builtBy remapJar
-			}
-			artifact(sourcesJar) {
-				builtBy remapSourcesJar
-			}
+			from components.java
 		}
-	}
-
-	// select the repositories you want to publish to
-	repositories {
-		// uncomment to publish to the local maven
-		// mavenLocal()
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/use
-	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.3
-	loader_version=0.14.11
+	# check these on https://fabricmc.net/develop/#latest-versions
+	minecraft_version=1.19.4
+	yarn_mappings=1.19.4+build.1
+	loader_version=0.14.18
 
 # Mod Properties
 	mod_version = 1.1.1
@@ -14,4 +14,4 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.69.0+1.19.3
+	fabric_version=0.76.0+1.19.4

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
 
   "depends": {
     "fabricloader": ">=0.14",
-    "minecraft": "1.19.3"
+    "minecraft": ">=1.19.3"
   },
   "suggests": {}
 }


### PR DESCRIPTION
There isn't really much of any reason for this mod to have a strict requirement on a specific Minecraft version. It's small enough that it can just be updated as necessary. It can be assumed to work on future versions until proven otherwise.
